### PR TITLE
Use reflections8 rather than reflections

### DIFF
--- a/Bukkit/pom.xml
+++ b/Bukkit/pom.xml
@@ -392,8 +392,8 @@
             <version>${adventure.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
             <version>${reflections.version}</version>
         </dependency>
         <dependency>

--- a/Bungee/pom.xml
+++ b/Bungee/pom.xml
@@ -354,8 +354,8 @@
             <version>${adventure.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
             <version>${reflections.version}</version>
         </dependency>
         <dependency>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -140,10 +140,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
             <version>${reflections.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spongepowered</groupId>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -143,6 +143,7 @@
             <groupId>net.oneandone.reflections8</groupId>
             <artifactId>reflections8</artifactId>
             <version>${reflections.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spongepowered</groupId>

--- a/Common/src/main/java/me/egg82/antivpn/config/ConfigurationFileUtil.java
+++ b/Common/src/main/java/me/egg82/antivpn/config/ConfigurationFileUtil.java
@@ -25,7 +25,7 @@ import me.egg82.antivpn.utils.TimeUtil;
 import me.egg82.antivpn.utils.ValidationUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.reflections.Reflections;
+import org.reflections8.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongepowered.configurate.CommentedConfigurationNode;
@@ -78,9 +78,6 @@ public class ConfigurationFileUtil {
         GELFLogger.doSendErrors(config.node("stats", "errors").getBoolean(true));
 
         boolean debug = config.node("debug").getBoolean(false);
-        if (!debug) {
-            Reflections.log = null;
-        }
         if (debug) {
             console.sendMessage("<c2>Debug</c2> <c1>enabled</c1>");
         }

--- a/Common/src/main/java/me/egg82/antivpn/reflect/PackageFilter.java
+++ b/Common/src/main/java/me/egg82/antivpn/reflect/PackageFilter.java
@@ -7,14 +7,14 @@ import java.util.List;
 import java.util.Set;
 import me.egg82.antivpn.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeElementsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-import org.reflections.util.FilterBuilder;
+import org.reflections8.ReflectionUtils;
+import org.reflections8.Reflections;
+import org.reflections8.scanners.ResourcesScanner;
+import org.reflections8.scanners.SubTypesScanner;
+import org.reflections8.scanners.TypeElementsScanner;
+import org.reflections8.util.ClasspathHelper;
+import org.reflections8.util.ConfigurationBuilder;
+import org.reflections8.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ public class PackageFilter {
 
         Reflections ref = new Reflections(config);
 
-        Set<String> typeSet = ref.getStore().keys("TypeElementsScanner");
+        Set<String> typeSet = ref.getStore().get("TypeElementsScanner").keySet();
         Set<Class<?>> set = new HashSet<>(ReflectionUtils.forNames(typeSet, ref.getConfiguration().getClassLoaders()));
         ArrayList<Class<T>> list = new ArrayList<>();
 
@@ -125,7 +125,7 @@ public class PackageFilter {
 
         Reflections ref = new Reflections(config);
 
-        Set<String> typeSet = ref.getStore().keys("TypeElementsScanner");
+        Set<String> typeSet = ref.getStore().get("TypeElementsScanner").keySet();
         Set<Class<?>> set = new HashSet<>(ReflectionUtils.forNames(typeSet, ref.getConfiguration().getClassLoaders()));
         ArrayList<Class<? extends T>> list = new ArrayList<>();
 

--- a/Common/src/main/java/me/egg82/antivpn/storage/AbstractJDBCStorageService.java
+++ b/Common/src/main/java/me/egg82/antivpn/storage/AbstractJDBCStorageService.java
@@ -21,9 +21,9 @@ import me.egg82.antivpn.storage.models.query.QPlayerModel;
 import me.egg82.antivpn.utils.VersionUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.reflections.Reflections;
-import org.reflections.ReflectionsException;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections8.Reflections;
+import org.reflections8.ReflectionsException;
+import org.reflections8.scanners.ResourcesScanner;
 
 public abstract class AbstractJDBCStorageService extends AbstractStorageService {
     protected Database connection;

--- a/Velocity/pom.xml
+++ b/Velocity/pom.xml
@@ -335,8 +335,8 @@
             <version>${adventure.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>net.oneandone.reflections8</groupId>
+            <artifactId>reflections8</artifactId>
             <version>${reflections.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <eventchain.version>3.0.0</eventchain.version>
         <depdownloader.version>2.2.16</depdownloader.version>
         <relocator.version>1.4</relocator.version>
-        <reflections.version>0.9.12</reflections.version>
+        <reflections.version>0.11.5</reflections.version>
         <javassist.version>3.27.0-GA</javassist.version>
 
         <plan.version>5.1-R0.4</plan.version>


### PR DESCRIPTION
This fixes an issue in reflections 0.9.12 which is well documented with the SubTypesScanner and TypeAnnotationsScanner. See https://github.com/ronmamo/reflections/issues/273 for more information

While this didn't necessarily affect AntiVPN directly, when we put this on one of our servers with the current reflections library, it caused 20 of our plugins to fail to load (due to reflections breaking with Java8).

This build is tested, and shouldn't affect anything for any end users. It replaces the org.reflections.reflections library with org.oneandone.reflections8.reflections8 library, which is maintained and fixes this bug.